### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+cache: bundler
 language: ruby
 bundler_args: --without kitchen_vagrant
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: ruby
+bundler_args: --without kitchen_vagrant
+rvm:
+  - 2.0.0
+  - 2.1.2
+script:
+  - bundle exec rubocop
+  - bundle exec foodcritic --exclude spec ./
+  - bundle exec rspec


### PR DESCRIPTION
This is the configuration file to have Travis automatically run Rubocop, Food Critic and ChefSpec with each check-in and pull request. It has to be enabled in the repository's "Settings"->"Webhooks and Services"->"Add Service" and select and configure "Travis CI". It is currently failing, but we'll work to get all the tests passing shortly to ensure code standards are met.

Here is an example of the (currently failing) tests running on my branch:
https://travis-ci.org/mattray/cisco-network-chef-cookbook
