### PR TITLE
Demo recipes cleanup

### DIFF
--- a/recipes/demo_cleanup.rb
+++ b/recipes/demo_cleanup.rb
@@ -77,6 +77,10 @@ cisco_interface 'Ethernet1/3' do
   switchport_mode 'default'
 end
 
+cisco_interface 'Ethernet1/4' do
+  switchport_mode 'default'
+end
+
 cisco_ospf_vrf 'SAMPLE foo' do
   action :destroy
 end

--- a/recipes/demo_cleanup.rb
+++ b/recipes/demo_cleanup.rb
@@ -64,12 +64,13 @@ cisco_interface 'loopback2' do
   action :destroy
 end
 
-cisco_interface 'Ethernet1/1' do
-  switchport_mode 'default'
-end
-
+# destroy sub-if first because of mtu dependency
 cisco_interface 'Ethernet1/1.1' do
   action :destroy
+end
+
+cisco_interface 'Ethernet1/1' do
+  switchport_mode 'default'
 end
 
 cisco_interface 'Ethernet1/3' do

--- a/recipes/demo_install.rb
+++ b/recipes/demo_install.rb
@@ -118,7 +118,6 @@ end
 
 cisco_interface 'Ethernet1/1.1' do
   encapsulation_dot1q 10
-  negotiate_auto false
 end
 
 cisco_interface 'Ethernet1/2' do

--- a/recipes/demo_install.rb
+++ b/recipes/demo_install.rb
@@ -150,7 +150,7 @@ cisco_ospf 'Sample' do
   action :create
 end
 
-cisco_interface_ospf 'Ethernet1/2' do
+cisco_interface_ospf 'Ethernet1/4' do
   action                         :create
   ospf                           'Sample'
   area                           200


### PR DESCRIPTION
Three fixes:
- Removed old `negotiate_auto` workaround
- Fixed `cisco_interface_ospf` test by using a clean interface
- Remove sub-interface before cleaning parent interface to avoid mtu dependency issue
