### PR TITLE
Pin rubocop to exact version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :test do
   gem 'foodcritic'
   gem 'rake', '~> 10.0'
   gem 'rspec'
-  gem 'rubocop', '~> 0.34'
+  gem 'rubocop', '= 0.34'
 end
 
 gem 'test-kitchen', git: 'https://github.com/test-kitchen/test-kitchen', branch: 'master'


### PR DESCRIPTION
Fix annoying CI failures due to non-backward-compatible rubocop changes in later versions.
