### PR TITLE
Idempotency fix for interface

### DIFF
--- a/libraries/provider_cisco_interface.rb
+++ b/libraries/provider_cisco_interface.rb
@@ -130,6 +130,7 @@ class Chef
       def set_layer2_properties
         # Disable switchport
         set_switchport_mode
+        @new_resource.switchport_trunk_allowed_vlan.delete!(' ')
         prop_set([:access_vlan, :switchport_autostate_exclude,
                   :switchport_trunk_allowed_vlan, :switchport_trunk_native_vlan,
                   :switchport_vtp


### PR DESCRIPTION
`switchport trunk allowed vlan` property had idempotency issues
when setting string with whitespace
#### Recipe

``` ruby
cisco_interface 'Ethernet1/3' do
  switchport_mode 'trunk'
  switchport_trunk_allowed_vlan '20, 30'
  switchport_trunk_native_vlan 40
end
```
#### Initial Setting of Property

``` bash
  * cisco_interface[ethernet1/3] action create[2016-02-15T19:14:20+00:00] INFO: Processing cisco_interface[ethernet1/3] action create (rob_test::demo_install line 130)

    - update switchport_mode disabled => trunk
    - update switchport_trunk_allowed_vlan '1-4094' => '20,30'
    - update switchport_trunk_native_vlan '1' => '40'
```
#### Idempotency

``` bash
* cisco_interface[ethernet1/2] action create[2016-02-15T19:14:50+00:00] INFO: Processing cisco_interface[ethernet1/2] action create (rob_test::demo_install line 126)
 (up to date)
```
