### PR TITLE
yaml fixes for cisco ohai plugins

### DIFF
--- a/files/default/vendor/gems/cisco_node_utils-1.3.0/lib/cisco_node_utils/cmd_ref/show_version.yaml
+++ b/files/default/vendor/gems/cisco_node_utils-1.3.0/lib/cisco_node_utils/cmd_ref/show_version.yaml
@@ -13,8 +13,11 @@ board:
 
 boot_image:
   _exclude: [ios_xr]
-  nexus:
-    get_value: "kick_file_name"
+  get_value: "kick_file_name"
+  N5k: &sys_img_isan
+    get_value: "isan_file_name"
+  N6k: *sys_img_isan
+  N7k: *sys_img_isan
 
 cpu:
   nexus:

--- a/files/default/vendor/gems/cisco_node_utils-1.3.0/lib/cisco_node_utils/cmd_ref/virtual_service.yaml
+++ b/files/default/vendor/gems/cisco_node_utils-1.3.0/lib/cisco_node_utils/cmd_ref/virtual_service.yaml
@@ -3,5 +3,6 @@
 services:
   _exclude: [ios_xr]
   multiple: true
+  get_data_format: nxapi_structured
   get_command: 'show virtual-service detail'
   get_context: ["TABLE_detail", "ROW_detail"]


### PR DESCRIPTION
**Summary:**
This fixes the `virtual_service` and `system_image` output across our nxos platforms.  I decided to just update the vendored gem directly instead of re-vendoring given the fix is so small.  This same update will be double committed to node_utils.

**Virtual Service Output Before Fix:**

```
  "virtual_service": {

  }
```

**Virtual Service Output After Fix:**

```
  "virtual_service": {
    "guestshell+": {
      "package_info": {
        "name": "guestshell.ova",
        "path": "/isanboot/bin/guestshell.ova"
      },
      "application": {
        "name": "GuestShell",
        "version": "2.1(0.0)",
        "descr": "Cisco Systems Guest Shell"
      },
      "signing": {
        "key_type": "Cisco release key",
        "method": "SHA-1"
      },
      "licensing": {
        "name": "None",
        "version": "None"
      },
      "reservation": {
        "disk": 175,
        "memory": 256,
        "cpu": 1
      }
    }
  }

  "virtual_service": {
    "oac": {
      "package_info": {
        "name": "oac.1.0.0.ova",
        "path": "bootflash:/oac.1.0.0.ova"
      },
      "application": {
        "name": "OpenAgentContainer",
        "version": "1.0",
        "descr": "Cisco Systems Open Agent Container"
      },
      "signing": {
        "key_type": "Cisco release key",
        "method": "SHA-1"
      },
      "licensing": {
        "name": "None",
        "version": "None"
      },
      "reservation": {
        "disk": 400,
        "memory": 256,
        "cpu": 1
      }
    }
  }

```

**System Image Output Before Fix on OAC:**

```
  "images": {
    "system_image": "bootflash:///n7000-s2-kickstart.7.3.1.D1.0.48.bin",
```

**System Image Output After Fix on OAC:**

```
  "images": {
    "system_image": "bootflash:///n7000-s2-dk9.7.3.1.D1.0.48.bin",
```

**System Image Output After Fix on N3K, remains unchanged**

```
{
  "images": {
    "system_image": "bootflash:///nxos.7.0.3.I2.3.bin",
```
