### PR TITLE
Documentation and Minor Recipe Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.2.0] - TBD 
 
 ### Added
+- Enabled all providers on the N8k platform.
 - Enabled cisco_vtp support on N5k and N6k platforms.
 
 ## [1.1.2] - 2016-02-24

--- a/README.md
+++ b/README.md
@@ -91,9 +91,18 @@ See the recipes directory for example usage of cisco providers and resources.
 
 ### <a name="provider-platform-support">Provider Support Across Platforms</a>
 
+A note about support for specific platform models:
+
+  * "**N9k**" support includes all N9xxx models.
+  * "**N3k**" support includes N30xx and N31xx models only. **_The N35xx model is not supported_.**
+  * "**N5k**" support includes N56xx models only. **_The N50xx and N55xx models are not supported at this time_.**
+  * "**N6k**" support includes all N6xxx models.
+  * "**N7k**" support includes all N7xxx models.
+  * "**N8k**" support includes all N8xxx models.
+
 * ✅ = Supported
 
-|   | N9k | N30xx | N31xx | N56xx | N6k | N7k | Caveats |
+|   | N9k | N3k | N5k | N6k | N7k | N8k |Caveats |
 |---|:---:|:-----:|:-----:|:-----:|:---:|:---:|:-------:|
 | [cisco_command_config](#type-cisco_command_config) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [cisco_interface](#type-cisco_interface) | ✅ | ✅ | ✅ | ✅* | ✅* | ✅ | [Caveat](#cisco_interface-caveats) |
@@ -163,10 +172,10 @@ The following resources are listed alphabetically.
 
 ### Type: cisco_command_config
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_command_config` resource allows raw configurations to be managed by chef. It serves as a stopgap until specialized resources are created. It has the following limitations:
 
@@ -204,10 +213,10 @@ end
 The `cisco_interface` resource is used to manage general configuration of all
 interface types, including ethernet, port-channel, loopback, and SVI (vlan).
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 #### <a name="cisco_interface-caveats">Caveats</a>
 
@@ -313,10 +322,10 @@ The same actions apply regardless.
 
 ### Type: cisco_interface_ospf
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_interface_ospf` resource is used to manage per-interface OSPF
 configuration properties. More broadly applicable OSPF configuration is
@@ -388,10 +397,10 @@ end
 
 ### Type: cisco_ospf
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_ospf` resource is used to enable/disable OSPF on the switch.
 More detailed OSPF configuration is managed by the `cisco_ospf_vrf` and
@@ -419,10 +428,10 @@ end
 
 ### Type: cisco_ospf_vrf
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_ospf_vrf` resource is used to manage per-VRF OSPF configuration,
 including the `default` VRF.
@@ -501,10 +510,10 @@ end
 
 ### Type: cisco_package
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_package` resource is a subclass of the Chef `yum_package` resource.
 Unlike `yum_package`, it will always install packages into the NX-OS native
@@ -536,10 +545,10 @@ See https://docs.chef.io/resource_package.html
 
 ### Type: cisco_snmp_community
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_snmp_community` resource is used to manage SNMP communities.
 
@@ -571,10 +580,10 @@ end
 
 ### Type: cisco_snmp_group
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_snmp_group` resource is used to manage SNMP groups. Cisco NX-OS
 defines SNMP groups based on user roles, so this resource is unable to create
@@ -600,10 +609,10 @@ end
 
 ### Type: cisco_snmp_server
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_snmp_server` resource is used to manage the SNMP server configuration
 on a node. There can only be one instance of this resource per node.
@@ -649,10 +658,10 @@ end
 
 ### Type: cisco_snmp_user
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_snmp_user` resource is used to manage SNMP user configuration.
 
@@ -706,10 +715,10 @@ end
 
 ### Type: cisco_tacacs_server
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_tacacs_server` resource is used to manage global TACACS+ server
 configuration. There can only be one instance of this resource per node.
@@ -755,10 +764,10 @@ end
 
 ### Type: cisco_tacacs_server_host
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_tacacs_server_host` resource is used to manage per-host TACACS+
 configuration.
@@ -797,10 +806,10 @@ end
 
 ### Type: cisco_vlan
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.1.0 | 1.1.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_vlan` resource is used to manage VLAN configuration.
 
@@ -835,10 +844,10 @@ end
 
 ### Type: cisco_vtp
 
-| Minimum Requirements | N9k | N30xx | N31xx | N56xx | N6k | N7k |
+| Minimum Requirements | N9k | N3k | N5k | N6k | N7k | N8k |
 |----------------------|:---:|:-----:|:-----:|:-----:|:---:|:---:|
-| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) |
-| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.0.1 | 1.2.0 | 1.2.0 | 1.1.0 |
+| OS Image | 7.0(3)I2(1) | 7.0(3)I2(1) | 7.3(0)N1(1) | 7.3(0)N1(1) | 7.3(0)D1(1) | 7.0(3)F1(1) |
+| Cisco Cookbook Version | 1.0.1 | 1.0.1 | 1.2.0 | 1.2.0 | 1.1.0 | 1.2.0 |
 
 The `cisco_vtp` resource is used to manage VLAN Trunking Protocol (VTP)
 configuration. There can only be one instance of this resource per node.

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ A note about support for specific platform models:
   * "**N7k**" support includes all N7xxx models.
   * "**N8k**" support includes all N8xxx models.
 
-* ✅ = Supported
+ ✅ = Supported
 
 |   | N9k | N3k | N5k | N6k | N7k | N8k |Caveats |
 |---|:---:|:-----:|:-----:|:-----:|:---:|:---:|:-------:|
 | [cisco_command_config](#type-cisco_command_config) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| [cisco_interface](#type-cisco_interface) | ✅ | ✅ | ✅ | ✅* | ✅* | ✅ | [Caveat](#cisco_interface-caveats) |
+| [cisco_interface](#type-cisco_interface) | ✅ | ✅ | ✅* | ✅* | ✅ | ✅ | [Caveat](#cisco_interface-caveats) |
 | [cisco_interface_ospf](#type-cisco_interface_ospf) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [cisco_ospf](#type-cisco_ospf) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [cisco_ospf_vrf](#type-cisco_ospf_vrf) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ A note about support for specific platform models:
   * "**N7k**" support includes all N7xxx models.
   * "**N8k**" support includes all N8xxx models.
 
- ✅ = Supported
+
+✅ = Supported
 
 |   | N9k | N3k | N5k | N6k | N7k | N8k |Caveats |
 |---|:---:|:-----:|:-----:|:-----:|:---:|:---:|:-------:|

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 This workflow map aids *users*, *developers* and *maintainers* of the cisco-cookbook project in selecting the appropriate document(s) for their task.
 
 * User Guides
-  * [README-agent-install.md](docs/README-agent-install.md) : Agent Installation and Configuration Guide
-  * [README-chef-provisioning.md](docs/README-chef-provisioning.md) : Automated Agent Installation and Configuration
-  * [README-package-provider.md](docs/README-package-provider.md) : Cisco Nexus Package Management using the Package Provider
+  * [README-agent-install] : Agent Installation and Configuration Guide
+  * [README-chef-provisioning.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-chef-provisioning.md) : Automated Agent Installation and Configuration
+  * [README-package-provider.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/rel120/recipe_doc_updates/docs/README-package-provider.md) : Cisco Nexus Package Management using the Package Provider
   * The remainder of this document is aimed at end users
 * Developer Guides
-  * [CONTRIBUTING.md](CONTRIBUTING.md) : Contribution guidelines
-  * [README-develop-resources-providers.md](docs/README-develop-resources-providers.md) : Developing New cisco-cookbook Resources and Providers
+  * [CONTRIBUTING.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/master/CONTRIBUTING.md) : Contribution guidelines
+  * [README-develop-resources-providers.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-develop-resources-providers.md) : Developing New cisco-cookbook Resources and Providers
 * Maintainers Guides
-  * [README-maintainers.md](docs/README-maintainers.md) : Guidelines for core maintainers of the cisco-cookbook project
+  * [README-maintainers.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-maintainers.md) : Guidelines for core maintainers of the cisco-cookbook project
   * All developer guides apply to maintainers as well
 
 
@@ -62,7 +62,7 @@ The set of supported network element platforms is continuously expanding. Please
 The `cisco-cookbook` is installed on the Chef server. Please see [The Chef Server](https://docs.chef.io/server/) for information on Chef server setup. See Chef's [knife cookbook site](https://docs.chef.io/knife_cookbook_site.html) for general information on Chef cookbook installation.
 
 #### Chef Client
-The Chef Client (agent) requires installation and setup on each device. Agent setup can be performed as a manual process or it may be automated. For more information please see the [README-agent-install.md](docs/README-agent-install.md) document for detailed instructions on agent installation and configuration on Cisco Nexus devices.
+The Chef Client (agent) requires installation and setup on each device. Agent setup can be performed as a manual process or it may be automated. For more information please see the [README-agent-install] document for detailed instructions on agent installation and configuration on Cisco Nexus devices.
 
 ##### Gems
 
@@ -914,3 +914,5 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+[README-agent-install]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-agent-install.md

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ This workflow map aids *users*, *developers* and *maintainers* of the cisco-cook
 
 * User Guides
   * [README-agent-install] : Agent Installation and Configuration Guide
-  * [README-chef-provisioning.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-chef-provisioning.md) : Automated Agent Installation and Configuration
-  * [README-package-provider.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/rel120/recipe_doc_updates/docs/README-package-provider.md) : Cisco Nexus Package Management using the Package Provider
+  * [README-chef-provisioning] : Automated Agent Installation and Configuration
+  * [README-package-provider] : Cisco Nexus Package Management using the Package Provider
   * The remainder of this document is aimed at end users
 * Developer Guides
-  * [CONTRIBUTING.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/master/CONTRIBUTING.md) : Contribution guidelines
-  * [README-develop-resources-providers.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-develop-resources-providers.md) : Developing New cisco-cookbook Resources and Providers
+  * [CONTRIBUTING] : Contribution guidelines
+  * [README-develop-resources-providers] : Developing New cisco-cookbook Resources and Providers
 * Maintainers Guides
-  * [README-maintainers.md](https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-maintainers.md) : Guidelines for core maintainers of the cisco-cookbook project
+  * [README-maintainers] : Guidelines for core maintainers of the cisco-cookbook project
   * All developer guides apply to maintainers as well
 
 
@@ -45,9 +45,9 @@ The `cisco-cookbook` allows a network administrator to manage Cisco Network Elem
 
 The Cisco Network Elements and Operating Systems managed by this cookbook are continuously expanding. Please refer to the [Provider Support Across Platforms](#provider-platform-support) section for details on currently supported hardware and software. The [Chef and Ruby Requirements](#chef-ruby-requirements) section also provides details on compatible Chef client and Ruby versions.
 
-This GitHub repository contains the latest version of the cisco-cookbook source code. Supported versions of the cisco-cookbook are available at Chef Supermarket. Please refer to [SUPPORT.md](SUPPORT.md) for additional details.
+This GitHub repository contains the latest version of the cisco-cookbook source code. Supported versions of the cisco-cookbook are available at Chef Supermarket. Please refer to [SUPPORT] for additional details.
 
-Contributions to this cookbook are welcome. Guidelines on contributions to the cookbook are captured in [CONTRIBUTING.md](CONTRIBUTING.md)
+Contributions to this cookbook are welcome. Guidelines on contributions to the cookbook are captured in [CONTRIBUTING]
 
 ## Cookbook Description
 
@@ -916,3 +916,9 @@ limitations under the License.
 ```
 
 [README-agent-install]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-agent-install.md
+[README-chef-provisioning]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-chef-provisioning.md
+[README-develop-resources-providers]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-develop-resources-providers.md
+[README-package-provider]: https://github.com/cisco/cisco-network-chef-cookbook/blob/rel120/recipe_doc_updates/docs/README-package-provider.md
+[README-maintainers]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-maintainers.md
+[CONTRIBUTING]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/CONTRIBUTING.md
+[SUPPORT]: https://github.com/cisco/cisco-network-chef-cookbook/blob/rel120/recipe_doc_updates/SUPPORT.md

--- a/README.md
+++ b/README.md
@@ -924,10 +924,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
+[CONTRIBUTING]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/CONTRIBUTING.md
 [README-agent-install]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-agent-install.md
 [README-chef-provisioning]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-chef-provisioning.md
 [README-develop-resources-providers]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-develop-resources-providers.md
 [README-package-provider]: https://github.com/cisco/cisco-network-chef-cookbook/blob/rel120/recipe_doc_updates/docs/README-package-provider.md
 [README-maintainers]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/docs/README-maintainers.md
-[CONTRIBUTING]: https://github.com/cisco/cisco-network-chef-cookbook/blob/master/CONTRIBUTING.md
 [SUPPORT]: https://github.com/cisco/cisco-network-chef-cookbook/blob/rel120/recipe_doc_updates/SUPPORT.md

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -24,7 +24,7 @@ This document describes chef-client installation and setup on Cisco Nexus switch
 #### Platform and Software Requirements
 See [Requirements](../README.md#requirements) for details on platform and software requirements.
 
-Please note: A virtual Nexus N9000/N3000 may be helpful for development and testing. Users with a valid [cisco.com](http://cisco.com) user ID can obtain a copy of a virtual Nexus N9000/N3000 by sending their [cisco.com](http://cisco.com) user ID in an email to <get-n9kv@cisco.com>. If you do not have a [cisco.com](http://cisco.com) user ID please register for one at [https://tools.cisco.com/IDREG/guestRegistration](https://tools.cisco.com/IDREG/guestRegistration)
+Please note: A virtual Nexus N9k/N3k may be helpful for development and testing. Users with a valid [cisco.com](http://cisco.com) user ID can obtain a copy of a virtual Nexus N9k/N3k by sending their [cisco.com](http://cisco.com) user ID in an email to <get-n9kv@cisco.com>. If you do not have a [cisco.com](http://cisco.com) user ID please register for one at [https://tools.cisco.com/IDREG/guestRegistration](https://tools.cisco.com/IDREG/guestRegistration)
 
 #### Disk space
 
@@ -35,10 +35,10 @@ chef-client software.
 NX-OS supports three possible environments for running third party software:
 `bash-shell`, `guestshell` and the `open agent container (OAC)`.
 
-|Environment                  | Supported Platforms                      |
-|-----------------------------|------------------------------------------|
-|`bash-shell` or `guestshell` | Cisco Nexus 30xx, 31xx, 93xx, 95xx, N9Kv |
-|`open agent container (OAC)` | Cisco Nexus 56xx, 60xx, 7xxx             |
+|Environment                  | Supported Platforms       |
+|-----------------------------|---------------------------|
+|`bash-shell` or `guestshell` | Cisco Nexus N3k, N8k, N9k |
+|`open agent container (OAC)` | Cisco Nexus N5k, N6k, N7k |
 
 You may run chef-client from either `bash-shell` or `guestshell` on supported platforms but not from both at the same time.
 
@@ -126,8 +126,8 @@ The `guestshell` container environment is enabled by default on most platforms; 
 
 The recommended minimum values are currently:
 ```bash
-  Disk   : 400MB
-  Memory : 400MB
+  Disk   : 500MB
+  Memory : 500MB
 ```
 
 Use the `show guestshell detail` command to display the current state of the guestshell:
@@ -151,10 +151,10 @@ Use the `guestshell resize rootfs` command to resize the guestshell filesystem. 
 n3k# guestshell resize rootfs ?
   <158-600>  New root filesystem size (in MB)
 
-n3k# guestshell resize rootfs 400
+n3k# guestshell resize rootfs 500
 Note: Please disable/enable or reboot the Guest shell for root filesystem to be resized
 
-n3k# guestshell resize memory 400
+n3k# guestshell resize memory 500
 Note: Please disable/enable or reboot the Guest shell for system memory to be resized
 
 n3k# guestshell reboot
@@ -371,9 +371,9 @@ curl 'https://www.chef.io/chef/install.sh' | bash
 <sup>1</sup> *Note: At the time of release 1.1.0 it appears that the `bash-shell` environment may encounter a certificate error on some platforms during chef-client install. The workaround for this problem is to use `wget` and manually install the chef-client rpm as shown:*
 
 ```bash
-wget https://opscode-omnibus-packages.s3.amazonaws.com/nexus/7/x86_64/chef-12.7.2-1.nexus7.x86_64.rpm --no-check-certificate
+wget https://packages.chef.io/stable/nexus/7/chef-12.10.24-1.nexus7.x86_64.rpm --no-check-certificate
 
-yum localinstall chef-12.7.2-1.nexus7.x86_64.rpm
+yum localinstall chef-12.10.24-1.nexus7.x86_64.rpm
 ```
 
 #### validation.pem

--- a/docs/README-chef-provisioning.md
+++ b/docs/README-chef-provisioning.md
@@ -32,11 +32,11 @@ Chef client software on the target agent node.
 NX-OS supports three possible environments for running third party software:
 `bash-shell`, `guestshell` and the `open agent container (OAC)`.
 
-Environment                  | Supported Platforms                      |
------------------------------|------------------------------------------|
-`bash-shell` | Cisco Nexus 30xx, 31xx, 93xx, 95xx, N9Kv |
-`guestshell` | Cisco Nexus 30xx, 31xx, 93xx, 95xx, N9Kv |
-`open agent container (OAC)` | Cisco Nexus 56xx, 60xx, 7xxx             |
+Environment                  | Supported Platforms       |
+-----------------------------|---------------------------|
+`bash-shell`                 | Cisco Nexus N3k, N8k, N9k |
+`guestshell`                 | Cisco Nexus N3k, N8k, N9k |
+`open agent container (OAC)` | Cisco Nexus N5k, N6k, N7k |
 
 You may run chef-client in any of the three supported environments but not simultaneously.
 

--- a/docs/README-maintainers.md
+++ b/docs/README-maintainers.md
@@ -43,12 +43,12 @@ When we are considering publishing a new release, all of the following steps mus
     ```
 
 2. <a name="test-platforms">Run all tests (demo recipes, serverspec, kitchen, etc.) against the latest software release or release candidate for each supported platform:</a>
-  * N30xx
-  * N31xx
-  * N9xxx
-  * N56xx
-  * N60xx
-  * N7xxx
+  * N3k
+  * N5k
+  * N6k
+  * N7k
+  * N8k
+  * N9k
 
 3. Triage any test failures.
 

--- a/recipes/demo_cleanup.rb
+++ b/recipes/demo_cleanup.rb
@@ -19,29 +19,6 @@
 # This is just a cleanup for the demo_install recipe.
 # ----------------------------------------------------
 
-Chef::Log.info('Case 1. Package Mgmt: Cisco RPM, Cisco RPM Patch')
-cisco_package 'bgp-dev' do
-  action :remove
-end
-
-cisco_package 'n9000_sample' do
-  action :remove
-end
-
-# ----------------------------------------------------
-
-Chef::Log.info('Case 2. Package Mgmt: 3rd Party RPM')
-
-service 'demo-one' do
-  action :stop
-end
-
-cisco_package 'demo-one' do
-  action :remove
-end
-
-# ----------------------------------------------------
-
 Chef::Log.info('Case 3. Cisco Command Config')
 
 cisco_command_config 'cleanup-all' do

--- a/recipes/demo_patch_cleanup.rb
+++ b/recipes/demo_patch_cleanup.rb
@@ -24,7 +24,7 @@ cisco_package 'bgp-dev' do
   action :remove
 end
 
-cisco_package 'n9000_sample' do
+cisco_package 'CSCuxdublin' do
   action :remove
 end
 

--- a/recipes/demo_patch_install.rb
+++ b/recipes/demo_patch_install.rb
@@ -20,19 +20,19 @@
 # the arguments in a single column rather than following rubocop's style.
 
 # Uncomment the following resources to run on N3k, N8k, or N9k
- cookbook_file '/bootflash/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm' do
-   owner  'root'
-   group  'root'
-   mode   '0775'
-   source 'rpm-store/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
- end
+cookbook_file '/bootflash/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm' do
+  owner  'root'
+  group  'root'
+  mode   '0775'
+  source 'rpm-store/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
+end
 
- cisco_package 'CSCuxdublin' do
-   action :install
-   # action :remove
-   # package_settings {'target' => 'host'}
-   source '/bootflash/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
- end
+cisco_package 'CSCuxdublin' do
+  action :install
+  # action :remove
+  # package_settings {'target' => 'host'}
+  source '/bootflash/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
+end
 
 Chef::Log.info('Install third party package:')
 

--- a/recipes/demo_patch_install.rb
+++ b/recipes/demo_patch_install.rb
@@ -20,19 +20,19 @@
 # the arguments in a single column rather than following rubocop's style.
 
 # Uncomment the following resources to run on N3k, N8k, or N9k
-# cookbook_file '/bootflash/n9000_sample-1.0.0-7.0.3.x86_64.rpm' do
-#   owner  'root'
-#   group  'root'
-#   mode   '0775'
-#   source 'rpm-store/n9000_sample-1.0.0-7.0.3.x86_64.rpm'
-# end
-#
-# cisco_package 'n9000_sample' do
-#   action :install
-#   # action :remove
-#   # package_settings {'target' => 'host'}
-#   source '/bootflash/n9000_sample-1.0.0-7.0.3.x86_64.rpm'
-# end
+ cookbook_file '/bootflash/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm' do
+   owner  'root'
+   group  'root'
+   mode   '0775'
+   source 'rpm-store/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
+ end
+
+ cisco_package 'CSCuxdublin' do
+   action :install
+   # action :remove
+   # package_settings {'target' => 'host'}
+   source '/bootflash/CSCuxdublin-1.0.0-7.0.3.I3.1.lib32_n9000.rpm'
+ end
 
 Chef::Log.info('Install third party package:')
 


### PR DESCRIPTION
**Summary:**
- Add `n8k` support references.
- Add `n5|6k` support references for `cisco_vtp`.
- Updated README links to point to `master` instead of using relative links.
- Updated demo_patch_install recipe to use dublin patch and remove patch recipe info from demo_cleanup.
- Updated GS rootfs and memory to 500MB.
- Updated pointer to latest chef-client RPM in docs.
