### PR TITLE
command_config: undefined method 'previous'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache: bundler
 language: ruby
 bundler_args: --without kitchen_vagrant
 rvm:
-  - 2.0.0
   - 2.1.2
 script:
   - bundle exec rubocop

--- a/libraries/provider_cisco_command_config.rb
+++ b/libraries/provider_cisco_command_config.rb
@@ -91,8 +91,9 @@ class Chef
           end
         end
       rescue Cisco::CliError => e
-        Chef::Log.info "Successfully updated:\n#{e.previous.join("\n")}" \
-          unless e.previous.empty?
+        unless e.successful_input.empty?
+          Chef::Log.info "Successfully updated:\n#{e.successful_input.join("\n")}"
+        end
         raise
       end
     end


### PR DESCRIPTION
- Symptom: Simple cc recipe with a faulty line of config:

```
    cisco_command_config 'loop42' do
      action :update
      command '
        interface loopback42
        ip pim foo
      '
    end
```

When chef-client runs the cc provider drops into a rescue which should first print out the parts of the config that were successfully processed and then do a raise, but instead we see:

```
        NoMethodError
        -------------
        undefined method `previous' for #<Cisco::CliError:0x00000005208488>

```
- Analysis: `client.rb` was refactored a few months ago, wherein the `previous` hash key was renamed to `successful_input`. The cc providers (both puppet & chef) never got updated with the new key name.
  - Ref: https://github.com/cisco/cisco-network-node-utils/blob/develop/lib/cisco_node_utils/client/nxapi/client.rb#L285
- Testing:

```
    Linux# chef-client --once
     ...
    Recipe: cisco-cookbook::cvh
      * cisco_command_config[loop42] action update[2016-07-15T19:20:57+04:00] INFO: Processing cisco_command_config[loop42] action update (cisco-cookbook::cvh line 24)

        ================================================================================
        Error executing action `update` on resource 'cisco_command_config[loop42]'
        ================================================================================

        Cisco::CliError
        ---------------
        The command 'ip pim foo' was rejected with error:
        % Invalid command

```
