### PR TITLE
Hamilton docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ cache: bundler
 language: ruby
 bundler_args: --without kitchen_vagrant
 rvm:
-  - 2.1.2
+  - 2.2.2
 matrix:
   include:
-    - rvm: 2.1.2
+    - rvm: 2.2.2
       gemfile: Gemfile
 script:
   - bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-**NOTE:** Starting in release `9.2(1)` and later, installing the Chef Client into the `bash-shell` hosting environment is no longer supported.
+**NOTE:** Starting in release `9.2(1)` and onward, installing the chef-client into the `bash-shell` hosting environment is no longer supported.
 
-The Chef Client software must be installed on a Cisco Nexus platform in the `Guestshell` (the Linux container environment running CentOS). This provides a secure, open execution environment that is decoupled from the host.
+The chef-client software must be installed on a Cisco Nexus platform in the `Guestshell` (the Linux container environment running CentOS). This provides a secure, open execution environment that is decoupled from the host.
 
 
 ### New feature support
@@ -16,7 +16,7 @@ The Chef Client software must be installed on a Cisco Nexus platform in the `Gue
 *
 
 ### Removed
-* Support for Chef Client install into the `bash-shell` hosting environment. This is the native WRL Linux environment underlying NX-OS.
+* Support for chef-client install into the `bash-shell` hosting environment. This is the native WRL Linux environment underlying NX-OS.
 
 ## [1.2.1] - 2017-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-**NOTE:** Starting in release `9.2(1)` and later, installing the Chef client into the `bash-shell` hosting environment is no longer supported.
+**NOTE:** Starting in release `9.2(1)` and later, installing the Chef Client into the `bash-shell` hosting environment is no longer supported.
 
-The Chef client software must be installed on a Cisco Nexus platform in the `Guestshell` (the Linux container environment running CentOS). This provides a secure, open execution environment that is decoupled from the host.
+The Chef Client software must be installed on a Cisco Nexus platform in the `Guestshell` (the Linux container environment running CentOS). This provides a secure, open execution environment that is decoupled from the host.
 
 
 ### New feature support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+**NOTE:** Starting in release `9.2(1)` and later, installing the Chef client into the `bash-shell` hosting environment is no longer supported.
+
+The Chef client software must be installed on a Cisco Nexus platform in the `Guestshell` (the Linux container environment running CentOS). This provides a secure, open execution environment that is decoupled from the host.
+
+
 ### New feature support
 *
 
@@ -11,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 *
 
 ### Removed
-*
+* Support for Chef Client install into the `bash-shell` hosting environment. This is the native WRL Linux environment underlying NX-OS.
 
 ## [1.2.1] - 2017-09-26
 

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -35,6 +35,9 @@ chef-client software.
 NX-OS supports three possible environments for running third party software:
 `bash-shell`, `guestshell` and the `open agent container (OAC)`.
 
+**NOTE:** Starting in release `9.2(1)` and later, installing the chef-client into the `bash-shell` hosting environment is no longer supported.  Instead the chef-client software should be installed into the [`guestshell` hosting environment](#env-gs).
+
+
 |Environment                  | Supported Platforms       |
 |-----------------------------|---------------------------|
 |`bash-shell` or `guestshell` | Cisco Nexus N3k, N9k, N9k-F |
@@ -73,6 +76,9 @@ end
 ```
 
 ## <a name="env-bs">chef-client Environment: bash-shell</a>
+
+**NOTE:** Starting in release `9.2(1)` and later, installing the chef-client into the `bash-shell` hosting environment is no longer supported.  Instead the chef-client software should be installed into the [`guestshell` hosting environment](#env-gs).
+
 
 This section is only necessary if chef-client will run from the `bash-shell`.
 

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -35,7 +35,7 @@ chef-client software.
 NX-OS supports three possible environments for running third party software:
 `bash-shell`, `guestshell` and the `open agent container (OAC)`.
 
-**NOTE:** Starting in release `9.2(1)` and later, installing the chef-client into the `bash-shell` hosting environment is no longer supported.  Instead the chef-client software should be installed into the [`guestshell` hosting environment](#env-gs).
+**NOTE:** Starting in release `9.2(1)` and onward, installing the chef-client into the `bash-shell` hosting environment is no longer supported.  Instead the chef-client software should be installed into the [`guestshell` hosting environment](#env-gs).
 
 
 |Environment                  | Supported Platforms       |
@@ -77,7 +77,7 @@ end
 
 ## <a name="env-bs">chef-client Environment: bash-shell</a>
 
-**NOTE:** Starting in release `9.2(1)` and later, installing the chef-client into the `bash-shell` hosting environment is no longer supported.  Instead the chef-client software should be installed into the [`guestshell` hosting environment](#env-gs).
+**NOTE:** Starting in release `9.2(1)` and onward, installing the chef-client into the `bash-shell` hosting environment is no longer supported.  Instead the chef-client software should be installed into the [`guestshell` hosting environment](#env-gs).
 
 
 This section is only necessary if chef-client will run from the `bash-shell`.
@@ -134,7 +134,7 @@ The `guestshell` container environment is enabled by default on most platforms; 
 ##### Special notes about low footprint N3k switches:
   * Nexus 3xxx switches with 4 GB RAM and 1.6 GB bootflash are advised to use compacted images to reduce the storage resources consumed by the image. As part of the compaction process, the `guestshell.ova` is removed from the system image.  To make use of the guestshell on these systems, the guestshell.ova may be downloaded and used to install the guestshell.
 
-  * Starting in release `9.2(1)` and later, the .ova file can be copied to the `volatile:` directory which frees up more space on `bootflash:`.
+  * Starting in release `9.2(1)` and onward, the .ova file can be copied to the `volatile:` directory which frees up more space on `bootflash:`.
 
 Copy the `guestshell.ova` file to `volatile:` if supported, otherwise copy it to `bootflash:`
 

--- a/docs/README-agent-install.md
+++ b/docs/README-agent-install.md
@@ -130,6 +130,26 @@ This section is only necessary if chef-client will run from the `guestshell`.
 
 The `guestshell` container environment is enabled by default on most platforms; however, the default disk and memory resources allocated to the guestshell container may be too small to support chef-client requirements. These resource limits may be increased with the NX-OS CLI `guestshell resize` commands as shown below.
 
+---
+##### Special notes about low footprint N3k switches:
+  * Nexus 3xxx switches with 4 GB RAM and 1.6 GB bootflash are advised to use compacted images to reduce the storage resources consumed by the image. As part of the compaction process, the `guestshell.ova` is removed from the system image.  To make use of the guestshell on these systems, the guestshell.ova may be downloaded and used to install the guestshell.
+
+  * Starting in release `9.2(1)` and later, the .ova file can be copied to the `volatile:` directory which frees up more space on `bootflash:`.
+
+Copy the `guestshell.ova` file to `volatile:` if supported, otherwise copy it to `bootflash:`
+
+```
+n3xxx# copy scp://admin@1.2.3.4/guestshell.ova volatile: vrf management
+guestshell.ova 100% 55MB 10.9MB/s 00:05 
+Copy complete, now saving to disk (please wait)...
+Copy complete.
+```
+
+Use the `guestshell enable` command to install and enable guestshell.
+
+`n3xxx# guestshell enable package volatile:guestshell.ova`
+
+---
 The recommended minimum values are currently:
 ```bash
   Disk   : 500MB


### PR DESCRIPTION
**Summary:**
This PR updates documentation for the following:
  * Indicate that chef-client installs into the `bash-shell `are no longer supported.
  * Add n3k low footprint workflow when using `guestshell`